### PR TITLE
feat: use `pull_request_target` to execute only workflows defined on main

### DIFF
--- a/.github/workflows/benchmark-pull-request.yaml
+++ b/.github/workflows/benchmark-pull-request.yaml
@@ -1,11 +1,12 @@
 name: Benchmark PR
 
 on:
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
     paths: ["projects/**"]
     types: [opened, reopened, synchronize, labeled]
-    branches: [main]
-
+    
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
fixes: #15